### PR TITLE
ELPP-3492 AMQP examples for PHP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/events/php/vendor/

--- a/events/php/composer.json
+++ b/events/php/composer.json
@@ -4,8 +4,8 @@
     "type": "project",
     "require": {
         "enqueue/enqueue": "^0.8.23",
-        "enqueue/amqp-lib": "*",
-        "php-amqplib/php-amqplib": "*"
+        "enqueue/amqp-lib": "^0.8.23",
+        "php-amqplib/php-amqplib": "^2.0"
     },
     "license": "MIT"
 }

--- a/events/php/composer.json
+++ b/events/php/composer.json
@@ -1,0 +1,10 @@
+{
+    "name": "elife/libero-events-php",
+    "description": "Demonstrations of events usage from a PHP application",
+    "type": "project",
+    "require": {
+        "enqueue/enqueue": "^0.8.23",
+        "enqueue/amqp-lib": "*"
+    },
+    "license": "MIT"
+}

--- a/events/php/composer.json
+++ b/events/php/composer.json
@@ -4,7 +4,8 @@
     "type": "project",
     "require": {
         "enqueue/enqueue": "^0.8.23",
-        "enqueue/amqp-lib": "*"
+        "enqueue/amqp-lib": "*",
+        "php-amqplib/php-amqplib": "*"
     },
     "license": "MIT"
 }

--- a/events/php/composer.lock
+++ b/events/php/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "722b3c1c262ef8cff3e71b2b246969ec",
+    "content-hash": "7a0c07bf21e7cbf7be016e45e2165ace",
     "packages": [
         {
             "name": "enqueue/amqp-lib",

--- a/events/php/composer.lock
+++ b/events/php/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "7a0c07bf21e7cbf7be016e45e2165ace",
+    "content-hash": "853f6dbd42ca442ae2521ddb44cf54eb",
     "packages": [
         {
             "name": "enqueue/amqp-lib",

--- a/events/php/composer.lock
+++ b/events/php/composer.lock
@@ -1,0 +1,595 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "722b3c1c262ef8cff3e71b2b246969ec",
+    "packages": [
+        {
+            "name": "enqueue/amqp-lib",
+            "version": "0.8.23",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-enqueue/amqp-lib.git",
+                "reference": "02a65b6e73495fa84479724ae2b18b1766ae9d8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-enqueue/amqp-lib/zipball/02a65b6e73495fa84479724ae2b18b1766ae9d8c",
+                "reference": "02a65b6e73495fa84479724ae2b18b1766ae9d8c",
+                "shasum": ""
+            },
+            "require": {
+                "enqueue/amqp-tools": "^0.8.5@dev",
+                "php": ">=5.6",
+                "php-amqplib/php-amqplib": "^2.7@dev",
+                "queue-interop/amqp-interop": "^0.7@dev",
+                "queue-interop/queue-interop": "^0.6@dev|^1.0.0-alpha1"
+            },
+            "require-dev": {
+                "enqueue/enqueue": "^0.8@dev",
+                "enqueue/null": "^0.8@dev",
+                "enqueue/test": "^0.8@dev",
+                "phpunit/phpunit": "~5.4.0",
+                "queue-interop/queue-spec": "^0.5.3@dev",
+                "symfony/config": "^2.8|^3|^4",
+                "symfony/dependency-injection": "^2.8|^3|^4"
+            },
+            "suggest": {
+                "enqueue/enqueue": "If you'd like to use advanced features like Client abstract layer or Symfony integration features"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Enqueue\\AmqpLib\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Message Queue Amqp Transport",
+            "homepage": "https://enqueue.forma-pro.com/",
+            "keywords": [
+                "AMQP",
+                "messaging",
+                "queue"
+            ],
+            "time": "2018-03-06T10:46:03+00:00"
+        },
+        {
+            "name": "enqueue/amqp-tools",
+            "version": "0.8.23",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-enqueue/amqp-tools.git",
+                "reference": "e401314d9548a7327b78de1bf48af7b3a098a57d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-enqueue/amqp-tools/zipball/e401314d9548a7327b78de1bf48af7b3a098a57d",
+                "reference": "e401314d9548a7327b78de1bf48af7b3a098a57d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6",
+                "queue-interop/amqp-interop": "^0.7@dev",
+                "queue-interop/queue-interop": "^0.6@dev|^1.0.0-alpha1"
+            },
+            "require-dev": {
+                "enqueue/null": "^0.8@dev",
+                "enqueue/test": "^0.8@dev",
+                "phpunit/phpunit": "~5.4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Enqueue\\AmqpTools\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Message Queue Amqp Tools",
+            "homepage": "https://enqueue.forma-pro.com/",
+            "keywords": [
+                "AMQP",
+                "messaging",
+                "queue"
+            ],
+            "time": "2018-03-06T10:46:03+00:00"
+        },
+        {
+            "name": "enqueue/enqueue",
+            "version": "0.8.23",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-enqueue/enqueue.git",
+                "reference": "b185069135994ba28f1a1c9c0d9cf2293f8e3b5c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-enqueue/enqueue/zipball/b185069135994ba28f1a1c9c0d9cf2293f8e3b5c",
+                "reference": "b185069135994ba28f1a1c9c0d9cf2293f8e3b5c",
+                "shasum": ""
+            },
+            "require": {
+                "enqueue/null": "^0.8@dev",
+                "php": ">=5.6",
+                "psr/log": "^1",
+                "queue-interop/queue-interop": "^0.6@dev|^1.0.0-alpha1",
+                "ramsey/uuid": "^2|^3.5"
+            },
+            "require-dev": {
+                "empi89/php-amqp-stubs": "*@dev",
+                "enqueue/amqp-bunny": "^0.8@dev",
+                "enqueue/amqp-ext": "^0.8@dev",
+                "enqueue/amqp-lib": "^0.8@dev",
+                "enqueue/dbal": "^0.8@dev",
+                "enqueue/fs": "^0.8@dev",
+                "enqueue/gearman": "^0.8@dev",
+                "enqueue/gps": "^0.8@dev",
+                "enqueue/pheanstalk": "^0.8@dev",
+                "enqueue/rdkafka": "^0.8@dev",
+                "enqueue/redis": "^0.8@dev",
+                "enqueue/simple-client": "^0.8@dev",
+                "enqueue/sqs": "^0.8@dev",
+                "enqueue/stomp": "^0.8@dev",
+                "enqueue/test": "^0.8@dev",
+                "phpunit/phpunit": "~5.5",
+                "symfony/config": "^2.8|^3|^4",
+                "symfony/console": "^2.8|^3|^4",
+                "symfony/dependency-injection": "^2.8|^3|^4",
+                "symfony/event-dispatcher": "^2.8|^3|^4",
+                "symfony/http-kernel": "^2.8|^3|^4"
+            },
+            "suggest": {
+                "enqueue/amqp-ext": "AMQP transport (based on php extension)",
+                "enqueue/dbal": "Doctrine DBAL transport",
+                "enqueue/fs": "Filesystem transport",
+                "enqueue/redis": "Redis transport",
+                "enqueue/sqs": "Amazon AWS SQS transport",
+                "enqueue/stomp": "STOMP transport",
+                "symfony/config": "^2.8|^3|^4",
+                "symfony/console": "^2.8|^3|^4 If you want to use li commands",
+                "symfony/dependency-injection": "^2.8|^3|^4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Enqueue\\": ""
+                },
+                "files": [
+                    "functions_include.php"
+                ],
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Message Queue Library",
+            "homepage": "https://enqueue.forma-pro.com/",
+            "keywords": [
+                "AMQP",
+                "messaging",
+                "queue",
+                "rabbitmq"
+            ],
+            "time": "2018-03-06T10:46:03+00:00"
+        },
+        {
+            "name": "enqueue/null",
+            "version": "0.8.23",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-enqueue/null.git",
+                "reference": "9339c4a5921cbe791da66ea1db0316174021a43b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-enqueue/null/zipball/9339c4a5921cbe791da66ea1db0316174021a43b",
+                "reference": "9339c4a5921cbe791da66ea1db0316174021a43b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6",
+                "queue-interop/queue-interop": "^0.6@dev|^1.0.0-alpha1"
+            },
+            "require-dev": {
+                "enqueue/enqueue": "^0.8@dev",
+                "enqueue/test": "^0.8@dev",
+                "phpunit/phpunit": "~5.5",
+                "queue-interop/queue-spec": "^0.5.3@dev",
+                "symfony/config": "^2.8|^3|^4",
+                "symfony/dependency-injection": "^2.8|^3|^4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Enqueue\\Null\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Enqueue Null transport",
+            "homepage": "https://enqueue.forma-pro.com/",
+            "keywords": [
+                "messaging",
+                "queue",
+                "testing"
+            ],
+            "time": "2018-03-06T10:46:03+00:00"
+        },
+        {
+            "name": "paragonie/random_compat",
+            "version": "v2.0.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/random_compat.git",
+                "reference": "5da4d3c796c275c55f057af5a643ae297d96b4d8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/5da4d3c796c275c55f057af5a643ae297d96b4d8",
+                "reference": "5da4d3c796c275c55f057af5a643ae297d96b4d8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*|5.*"
+            },
+            "suggest": {
+                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/random.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com"
+                }
+            ],
+            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
+            "keywords": [
+                "csprng",
+                "pseudorandom",
+                "random"
+            ],
+            "time": "2017-09-27T21:40:39+00:00"
+        },
+        {
+            "name": "php-amqplib/php-amqplib",
+            "version": "v2.7.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-amqplib/php-amqplib.git",
+                "reference": "dfd3694a86f1a7394d3693485259d4074a6ec79b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-amqplib/php-amqplib/zipball/dfd3694a86f1a7394d3693485259d4074a6ec79b",
+                "reference": "dfd3694a86f1a7394d3693485259d4074a6ec79b",
+                "shasum": ""
+            },
+            "require": {
+                "ext-bcmath": "*",
+                "ext-mbstring": "*",
+                "php": ">=5.3.0"
+            },
+            "replace": {
+                "videlalvaro/php-amqplib": "self.version"
+            },
+            "require-dev": {
+                "phpdocumentor/phpdocumentor": "^2.9",
+                "phpunit/phpunit": "^4.8",
+                "scrutinizer/ocular": "^1.1",
+                "squizlabs/php_codesniffer": "^2.5"
+            },
+            "suggest": {
+                "ext-sockets": "Use AMQPSocketConnection"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpAmqpLib\\": "PhpAmqpLib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Alvaro Videla",
+                    "role": "Original Maintainer"
+                },
+                {
+                    "name": "John Kelly",
+                    "email": "johnmkelly86@gmail.com",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Raúl Araya",
+                    "email": "nubeiro@gmail.com",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "Formerly videlalvaro/php-amqplib.  This library is a pure PHP implementation of the AMQP protocol. It's been tested against RabbitMQ.",
+            "homepage": "https://github.com/php-amqplib/php-amqplib/",
+            "keywords": [
+                "message",
+                "queue",
+                "rabbitmq"
+            ],
+            "time": "2018-02-11T19:28:00+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "time": "2016-10-10T12:19:37+00:00"
+        },
+        {
+            "name": "queue-interop/amqp-interop",
+            "version": "0.7.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/queue-interop/amqp-interop.git",
+                "reference": "1a437a8efd7a6835198b0d16031d3ed38dbceeab"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/queue-interop/amqp-interop/zipball/1a437a8efd7a6835198b0d16031d3ed38dbceeab",
+                "reference": "1a437a8efd7a6835198b0d16031d3ed38dbceeab",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5",
+                "queue-interop/queue-interop": "^0.6@dev|^1.0.0-alpha1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~5.4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Interop\\Amqp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "time": "2018-03-06T10:44:28+00:00"
+        },
+        {
+            "name": "queue-interop/queue-interop",
+            "version": "0.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/queue-interop/queue-interop.git",
+                "reference": "38579005c0492c0275bbae31170edf30a7e740fa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/queue-interop/queue-interop/zipball/38579005c0492c0275bbae31170edf30a7e740fa",
+                "reference": "38579005c0492c0275bbae31170edf30a7e740fa",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Interop\\Queue\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Promoting the interoperability of MQs objects. Based on Java JMS",
+            "homepage": "https://github.com/queue-interop/queue-interop",
+            "keywords": [
+                "MQ",
+                "jms",
+                "message queue",
+                "messaging",
+                "queue"
+            ],
+            "time": "2017-08-10T11:24:15+00:00"
+        },
+        {
+            "name": "ramsey/uuid",
+            "version": "3.7.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ramsey/uuid.git",
+                "reference": "44abcdad877d9a46685a3a4d221e3b2c4b87cb76"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/44abcdad877d9a46685a3a4d221e3b2c4b87cb76",
+                "reference": "44abcdad877d9a46685a3a4d221e3b2c4b87cb76",
+                "shasum": ""
+            },
+            "require": {
+                "paragonie/random_compat": "^1.0|^2.0",
+                "php": "^5.4 || ^7.0"
+            },
+            "replace": {
+                "rhumsaa/uuid": "self.version"
+            },
+            "require-dev": {
+                "codeception/aspect-mock": "^1.0 | ~2.0.0",
+                "doctrine/annotations": "~1.2.0",
+                "goaop/framework": "1.0.0-alpha.2 | ^1.0 | ^2.1",
+                "ircmaxell/random-lib": "^1.1",
+                "jakub-onderka/php-parallel-lint": "^0.9.0",
+                "mockery/mockery": "^0.9.9",
+                "moontoast/math": "^1.1",
+                "php-mock/php-mock-phpunit": "^0.3|^1.1",
+                "phpunit/phpunit": "^4.7|^5.0",
+                "squizlabs/php_codesniffer": "^2.3"
+            },
+            "suggest": {
+                "ext-libsodium": "Provides the PECL libsodium extension for use with the SodiumRandomGenerator",
+                "ext-uuid": "Provides the PECL UUID extension for use with the PeclUuidTimeGenerator and PeclUuidRandomGenerator",
+                "ircmaxell/random-lib": "Provides RandomLib for use with the RandomLibAdapter",
+                "moontoast/math": "Provides support for converting UUID to 128-bit integer (in string form).",
+                "ramsey/uuid-console": "A console application for generating UUIDs with ramsey/uuid",
+                "ramsey/uuid-doctrine": "Allows the use of Ramsey\\Uuid\\Uuid as Doctrine field type."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Ramsey\\Uuid\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marijn Huizendveld",
+                    "email": "marijn.huizendveld@gmail.com"
+                },
+                {
+                    "name": "Thibaud Fabre",
+                    "email": "thibaud@aztech.io"
+                },
+                {
+                    "name": "Ben Ramsey",
+                    "email": "ben@benramsey.com",
+                    "homepage": "https://benramsey.com"
+                }
+            ],
+            "description": "Formerly rhumsaa/uuid. A PHP 5.4+ library for generating RFC 4122 version 1, 3, 4, and 5 universally unique identifiers (UUID).",
+            "homepage": "https://github.com/ramsey/uuid",
+            "keywords": [
+                "guid",
+                "identifier",
+                "uuid"
+            ],
+            "time": "2018-01-20T00:28:24+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}

--- a/events/php/receive_amqplib.php
+++ b/events/php/receive_amqplib.php
@@ -23,3 +23,4 @@ while (!$exit) {
     echo "Waiting for new message", PHP_EOL;
     $channel->wait();
 }
+echo "Graceful shutdown", PHP_EOL;

--- a/events/php/receive_amqplib.php
+++ b/events/php/receive_amqplib.php
@@ -1,0 +1,25 @@
+<?php
+use PhpAmqpLib\Message\AMQPMessage;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
+require_once 'vendor/autoload.php';
+$connection = new AMQPStreamConnection('localhost', 5672, 'guest', 'guest');
+$channel = $connection->channel();
+
+$exit = false;
+$signalHandler = function() use ($channel, &$exit) {
+    $channel->basic_cancel(null, false, true);
+    $exit = true;
+};
+pcntl_signal(SIGTERM, $signalHandler);
+pcntl_signal(SIGINT, $signalHandler);
+pcntl_signal(SIGQUIT, $signalHandler);
+
+$channel->basic_consume('dashboard', null, false, false, false, false, function(AMQPMessage $message) use ($channel) {
+    echo $message->body, PHP_EOL;
+    $channel->basic_ack($message->delivery_info['delivery_tag']);
+});
+
+while (!$exit) {
+    echo "Waiting for new message", PHP_EOL;
+    $channel->wait();
+}

--- a/events/php/receive_enqueue.php
+++ b/events/php/receive_enqueue.php
@@ -1,0 +1,17 @@
+<?php
+use Interop\Queue\PsrConnectionFactory;
+use Enqueue\AmqpLib\AmqpConnectionFactory;
+
+require_once 'vendor/autoload.php';
+
+$connectionFactory = new AmqpConnectionFactory('amqp:');
+/** @var PsrConnectionFactory $connectionFactory **/
+$psrContext = $connectionFactory->createContext();
+
+$source = $psrContext->createQueue('dashboard');
+
+$consumer = $psrContext->createConsumer($source);
+
+$message = $consumer->receive();
+echo $message->getBody(), PHP_EOL;
+$consumer->acknowledge($message);

--- a/events/php/send_amqplib.php
+++ b/events/php/send_amqplib.php
@@ -1,0 +1,27 @@
+<?php
+use PhpAmqpLib\Connection\AMQPStreamConnection;
+use PhpAmqpLib\Message\AMQPMessage;
+require_once 'vendor/autoload.php';
+
+$connection = new AMQPStreamConnection('localhost', 5672, 'guest', 'guest');
+$channel = $connection->channel();
+$channel->set_ack_handler(
+    function (AMQPMessage $message) {
+        echo "Message acked with content " . $message->body . PHP_EOL;
+    }
+);
+
+$channel->confirm_select();
+/*
+    name: $exchange
+    type: fanout
+    passive: false // don't check if an exchange with the same name exists
+    durable: false // the exchange won't survive server restarts
+    auto_delete: true //the exchange will be deleted once the channel is closed.
+*/
+//$channel->exchange_declare($exchange, 'fanout', false, false, true);
+$msg = new AMQPMessage((string) time());
+$channel->basic_publish($msg, 'articles');
+$channel->wait_for_pending_acks();
+$channel->close();
+$connection->close();

--- a/events/php/send_amqplib.php
+++ b/events/php/send_amqplib.php
@@ -12,14 +12,6 @@ $channel->set_ack_handler(
 );
 
 $channel->confirm_select();
-/*
-    name: $exchange
-    type: fanout
-    passive: false // don't check if an exchange with the same name exists
-    durable: false // the exchange won't survive server restarts
-    auto_delete: true //the exchange will be deleted once the channel is closed.
-*/
-//$channel->exchange_declare($exchange, 'fanout', false, false, true);
 $msg = new AMQPMessage((string) time());
 $channel->basic_publish($msg, 'articles');
 $channel->wait_for_pending_acks();

--- a/events/php/send_amqplib.php
+++ b/events/php/send_amqplib.php
@@ -12,7 +12,9 @@ $channel->set_ack_handler(
 );
 
 $channel->confirm_select();
-$msg = new AMQPMessage((string) time());
+$msg = new AMQPMessage((string) time(), [
+    'delivery_mode' => AMQPMessage::DELIVERY_MODE_PERSISTENT,
+]);
 $channel->basic_publish($msg, 'articles');
 $channel->wait_for_pending_acks();
 $channel->close();

--- a/events/php/send_enqueue.php
+++ b/events/php/send_enqueue.php
@@ -1,0 +1,21 @@
+<?php
+use Interop\Queue\PsrConnectionFactory;
+use Interop\Amqp\AmqpMessage;
+use Enqueue\AmqpLib\AmqpConnectionFactory;
+
+require_once 'vendor/autoload.php';
+
+$connectionFactory = new AmqpConnectionFactory('amqp:');
+/** @var PsrConnectionFactory $connectionFactory **/
+$psrContext = $connectionFactory->createContext();
+
+// TODO: set wrong name
+$destination = $psrContext->createTopic('articles');
+
+$message = $psrContext->createMessage(json_encode([
+    'myid' => time(),
+]));
+$message->setDeliveryMode(AmqpMessage::DELIVERY_MODE_PERSISTENT);
+echo $message->getBody(), PHP_EOL;
+
+$psrContext->createProducer()->send($destination, $message);

--- a/events/php/setup_amqplib.php
+++ b/events/php/setup_amqplib.php
@@ -1,0 +1,8 @@
+<?php
+use PhpAmqpLib\Connection\AMQPStreamConnection;
+require_once 'vendor/autoload.php';
+$connection = new AMQPStreamConnection('localhost', 5672, 'guest', 'guest');
+$channel = $connection->channel();
+$channel->queue_declare('dashboard', $passive = false, $durable = true, $exclusive = false, $autoDelete = false);
+$channel->exchange_declare('articles', 'fanout', $passive = false, $durable = true, $autoDelete = false);
+$channel->queue_bind('dashboard', 'articles');

--- a/events/php/setup_enqueue.php
+++ b/events/php/setup_enqueue.php
@@ -1,0 +1,25 @@
+<?php
+use Interop\Queue\PsrConnectionFactory;
+use Interop\Amqp\AmqpTopic;
+use Interop\Amqp\AmqpQueue;
+use Interop\Amqp\Impl\AmqpBind;
+use Enqueue\AmqpLib\AmqpConnectionFactory;
+
+require_once 'vendor/autoload.php';
+
+$connectionFactory = new AmqpConnectionFactory('amqp:');
+/** @var PsrConnectionFactory $connectionFactory **/
+$psrContext = $connectionFactory->createContext();
+
+$articlesTopic = $psrContext->createTopic('articles');
+$articlesTopic->setType(AmqpTopic::TYPE_FANOUT);
+$articlesTopic->setFlags(AmqpTopic::FLAG_DURABLE);
+$psrContext->declareTopic($articlesTopic);
+
+$dashboardQueue = $psrContext->createQueue('dashboard');
+$dashboardQueue->addFlag(AmqpQueue::FLAG_DURABLE);
+$psrContext->declareQueue($dashboardQueue);
+
+$psrContext->bind(new AmqpBind($articlesTopic, $dashboardQueue));
+
+

--- a/events/rabbitmq.sh
+++ b/events/rabbitmq.sh
@@ -2,4 +2,19 @@
 set -e
 
 # login as guest:guest on localhost:8080
-exec docker run --hostname my-rabbit --name some-rabbit -p 8080:15672 rabbitmq:3.7.3-management
+
+# detach from container
+# hostname: used by RabbitMQ as configuration
+# name: Docker container name for `docker start|stop`
+# port 8080: management UI
+# port 5672: AMQP 0.9 port
+# rabbitmq_data: anonymous volume for persistence
+# image: pinned, with management UI
+docker run \
+    -d \
+    --hostname my-rabbit \
+    --name some-rabbit \
+    -p 8080:15672 \
+    -p 5672:5672 \
+    -v rabbitmq_data:/var/lib/rabbitmq \
+    rabbitmq:3.7.3-management


### PR DESCRIPTION
Tested on RabbitMQ.

Two alternatives, the second is preferred:

- `enqueue` is an abstraction layer but it cannot fully support all reliability requirements (publisher confirms rather than just the asynchronous basic publish)
- `amqplib` is the official PHP client for RabbitMQ, which implements AMQP 0.9.1 and publisher confirms.