### PR TITLE
Improve MathML inclusion

### DIFF
--- a/api-dummy/public/schemas/libero/article/body.rng
+++ b/api-dummy/public/schemas/libero/article/body.rng
@@ -4,7 +4,7 @@
 
     <include href="../core.rng"/>
 
-    <start combine="choice">
+    <start>
 
         <element name="body">
             <ref name="libero.body.content"/>

--- a/api-dummy/public/schemas/libero/article/front.rng
+++ b/api-dummy/public/schemas/libero/article/front.rng
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <grammar xmlns="http://relaxng.org/ns/structure/1.0" ns="http://libero.pub">
-    
+
     <include href="../core.rng"/>
-    
-    <start combine="choice">
+
+    <start>
 
         <element name="front">
             <ref name="libero.front.content"/>

--- a/api-dummy/public/schemas/libero/extensions/mathml.rng
+++ b/api-dummy/public/schemas/libero/extensions/mathml.rng
@@ -3,7 +3,11 @@
 <grammar xmlns="http://relaxng.org/ns/structure/1.0" ns="http://libero.pub">
 
     <include href="https://www.w3.org/Math/RelaxNG/mathml3/mathml3-common.rng"
-        ns="http://www.w3.org/1998/Math/MathML"/>
+        ns="http://www.w3.org/1998/Math/MathML">
+        <start combine="choice">
+            <notAllowed/>
+        </start>
+    </include>
     <include href="https://www.w3.org/Math/RelaxNG/mathml3/mathml3-presentation.rng"
         ns="http://www.w3.org/1998/Math/MathML"/>
 
@@ -14,13 +18,13 @@
     <define name="libero.blocks.text.class" combine="choice">
         <ref name="libero.blocks.mathml"/>
     </define>
-    
+
     <define name="libero.blocks.mathml">
         <element name="mathml">
             <ref name="libero.blocks.mathml.content"/>
         </element>
     </define>
-    
+
     <define name="libero.blocks.mathml.content">
         <optional>
             <ref name="libero.attrib.id"/>


### PR DESCRIPTION
Originally required `combine="choice"` on the local `<start>` as the MathML schema contains a standalone `<start>`, but since we don't need that we can replace MathML's `<start>` with an empty `<start combine="choice">`.