### PR TITLE
Start standardising RELAX NG

### DIFF
--- a/api-dummy/public/schemas/elife/article/front.rng
+++ b/api-dummy/public/schemas/elife/article/front.rng
@@ -11,7 +11,7 @@
     <define name="libero.front.content" combine="interleave">
         <optional>
             <element name="digest">
-                <ref name="libero.attrib.id"/>
+                <ref name="libero.attributes.id"/>
                 <ref name="libero.blocks.limited.model"/>
             </element>
         </optional>

--- a/api-dummy/public/schemas/libero/article/body.rng
+++ b/api-dummy/public/schemas/libero/article/body.rng
@@ -20,7 +20,7 @@
         </define>
 
         <define name="libero.body.attributes">
-            <ref name="libero.attrib.lang"/>
+            <ref name="libero.attributes.lang"/>
         </define>
 
         <define name="libero.body.content">

--- a/api-dummy/public/schemas/libero/article/body.rng
+++ b/api-dummy/public/schemas/libero/article/body.rng
@@ -1,20 +1,32 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
-<grammar xmlns="http://relaxng.org/ns/structure/1.0" ns="http://libero.pub">
+<grammar ns="http://libero.pub" xmlns="http://relaxng.org/ns/structure/1.0"
+    xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">
 
     <include href="../core.rng"/>
 
     <start>
-
-        <element name="body">
-            <ref name="libero.body.content"/>
-        </element>
-
+        <ref name="libero.body"/>
     </start>
 
-    <define name="libero.body.content">
-        <ref name="libero.attrib.lang"/>
-        <ref name="libero.blocks.full.model"/>
-    </define>
+    <div>
+        <a:documentation>body element</a:documentation>
+
+        <define name="libero.body">
+            <element name="body">
+                <ref name="libero.body.attributes"/>
+                <ref name="libero.body.content"/>
+            </element>
+        </define>
+
+        <define name="libero.body.attributes">
+            <ref name="libero.attrib.lang"/>
+        </define>
+
+        <define name="libero.body.content">
+            <ref name="libero.blocks.full.model"/>
+        </define>
+
+    </div>
 
 </grammar>

--- a/api-dummy/public/schemas/libero/article/front.rng
+++ b/api-dummy/public/schemas/libero/article/front.rng
@@ -1,26 +1,75 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
-<grammar xmlns="http://relaxng.org/ns/structure/1.0" ns="http://libero.pub">
+<grammar ns="http://libero.pub" xmlns="http://relaxng.org/ns/structure/1.0"
+    xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">
 
     <include href="../core.rng"/>
 
     <start>
-
-        <element name="front">
-            <ref name="libero.front.content"/>
-        </element>
-
+        <ref name="libero.front"/>
     </start>
 
-    <define name="libero.front.content">
-        <ref name="libero.attrib.lang"/>
-        <element name="id">
+    <div>
+        <a:documentation>front element</a:documentation>
+
+        <define name="libero.front">
+            <element name="front">
+                <ref name="libero.front.attributes"/>
+                <ref name="libero.front.content"/>
+            </element>
+        </define>
+
+        <define name="libero.front.attributes">
+            <ref name="libero.attrib.lang"/>
+        </define>
+
+        <define name="libero.front.content">
+            <interleave>
+                <ref name="libero.front.content.id"/>
+                <ref name="libero.front.content.title"/>
+            </interleave>
+        </define>
+
+    </div>
+
+    <div>
+        <a:documentation>front/id element</a:documentation>
+
+        <define name="libero.front.content.id">
+            <element name="id">
+                <ref name="libero.front.content.id.attributes"/>
+                <ref name="libero.front.content.id.content"/>
+            </element>
+        </define>
+
+        <define name="libero.front.content.id.attributes">
+            <empty/>
+        </define>
+
+        <define name="libero.front.content.id.content">
             <ref name="libero.types.id"/>
-        </element>
-        <element name="title">
-            <ref name="libero.attrib.lang.optional"/>
+        </define>
+
+    </div>
+
+    <div>
+        <a:documentation>front/title element</a:documentation>
+
+        <define name="libero.front.content.title">
+            <element name="title">
+                <ref name="libero.front.content.title.attributes"/>
+                <ref name="libero.front.content.title.content"/>
+            </element>
+        </define>
+
+        <define name="libero.front.content.title.attributes">
+            <empty/>
+        </define>
+
+        <define name="libero.front.content.title.content">
             <ref name="libero.text.limited.model"/>
-        </element>
-    </define>
+        </define>
+
+    </div>
 
 </grammar>

--- a/api-dummy/public/schemas/libero/article/front.rng
+++ b/api-dummy/public/schemas/libero/article/front.rng
@@ -20,7 +20,7 @@
         </define>
 
         <define name="libero.front.attributes">
-            <ref name="libero.attrib.lang"/>
+            <ref name="libero.attributes.lang"/>
         </define>
 
         <define name="libero.front.content">

--- a/api-dummy/public/schemas/libero/core/attributes.rng
+++ b/api-dummy/public/schemas/libero/core/attributes.rng
@@ -1,37 +1,55 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<grammar xmlns="http://relaxng.org/ns/structure/1.0"
-    datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+<grammar ns="http://libero.pub" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
+    xmlns="http://relaxng.org/ns/structure/1.0"
+    xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">
 
-    <define name="libero.attrib.id">
-        <attribute name="id">
-            <ref name="libero.types.id"/>
-        </attribute>
-    </define>
+    <div>
+        <a:documentation>@id attribute</a:documentation>
 
-    <define name="libero.attrib.lang.optional">
-        <optional>
-            <ref name="libero.attrib.lang"/>
-        </optional>
-    </define>
-
-    <define name="libero.attrib.lang">
-        <attribute name="xml:lang">
-            <choice>
-                <data type="language"/>
-            </choice>
-        </attribute>
-    </define>
-
-    <define name="libero.attrib.space">
-        <optional>
-            <attribute name="xml:space">
-                <choice>
-                    <value>default</value>
-                    <value>preserve</value>
-                </choice>
+        <define name="libero.attributes.id">
+            <attribute name="id">
+                <ref name="libero.attributes.id.content"/>
             </attribute>
-        </optional>
-    </define>
+        </define>
+
+        <define name="libero.attributes.id.content">
+            <ref name="libero.types.id"/>
+        </define>
+
+    </div>
+
+    <div>
+        <a:documentation>@xml:lang attribute</a:documentation>
+
+        <define name="libero.attributes.lang">
+            <attribute name="xml:lang">
+                <ref name="libero.attributes.id.content"/>
+            </attribute>
+        </define>
+
+        <define name="libero.attributes.lang.content">
+            <data type="language"/>
+        </define>
+
+    </div>
+
+    <div>
+        <a:documentation>@xml:space attribute</a:documentation>
+
+        <define name="libero.attributes.space">
+            <attribute name="xml:space">
+                <ref name="libero.attributes.space.content"/>
+            </attribute>
+        </define>
+
+        <define name="libero.attributes.space.content">
+            <choice>
+                <value>default</value>
+                <value>preserve</value>
+            </choice>
+        </define>
+
+    </div>
 
 </grammar>

--- a/api-dummy/public/schemas/libero/core/block.rng
+++ b/api-dummy/public/schemas/libero/core/block.rng
@@ -6,11 +6,13 @@
     <define name="libero.blocks.object.model">
         <interleave>
             <optional>
-                <ref name="libero.attrib.id"/>
+                <ref name="libero.attributes.id"/>
             </optional>
             <optional>
                 <element name="title">
-                    <ref name="libero.attrib.lang.optional"/>
+                    <optional>
+                        <ref name="libero.attributes.lang"/>
+                    </optional>
                     <ref name="libero.text.limited.model"/>
                 </element>
             </optional>
@@ -48,7 +50,9 @@
     <define name="libero.blocks.figure.asset.model">
         <interleave>
             <element name="label">
-                <ref name="libero.attrib.lang.optional"/>
+                <optional>
+                    <ref name="libero.attributes.lang"/>
+                </optional>
                 <ref name="libero.text.limited.model"/>
             </element>
             <ref name="libero.blocks.figure.asset.class"/>
@@ -118,7 +122,9 @@
         <interleave>
             <ref name="libero.blocks.object.model"/>
             <element name="label">
-                <ref name="libero.attrib.lang.optional"/>
+                <optional>
+                    <ref name="libero.attributes.lang"/>
+                </optional>
                 <ref name="libero.text.limited.model"/>
             </element>
             <element name="source">
@@ -194,7 +200,9 @@
     </define>
 
     <define name="libero.blocks.paragraph.model">
-        <ref name="libero.attrib.lang.optional"/>
+        <optional>
+            <ref name="libero.attributes.lang"/>
+        </optional>
         <ref name="libero.text.full.model"/>
     </define>
 

--- a/api-dummy/public/schemas/libero/core/inline.rng
+++ b/api-dummy/public/schemas/libero/core/inline.rng
@@ -16,55 +16,69 @@
                 <ref name="libero.types.uri.fragment"/>
             </choice>
         </attribute>
-        <ref name="libero.attrib.lang.optional"/>
+        <optional>
+            <ref name="libero.attributes.lang"/>
+        </optional>
         <ref name="libero.text.full.model"/>
     </define>
 
     <define name="libero.text.b">
         <element name="b">
-            <ref name="libero.attrib.lang.optional"/>
+            <optional>
+                <ref name="libero.attributes.lang"/>
+            </optional>
             <ref name="libero.text.full.model"/>
         </element>
     </define>
 
     <define name="libero.text.foreign">
         <element name="foreign">
-            <ref name="libero.attrib.lang"/>
+            <ref name="libero.attributes.lang"/>
             <ref name="libero.text.limited.model"/>
         </element>
     </define>
 
     <define name="libero.text.i">
         <element name="i">
-            <ref name="libero.attrib.lang.optional"/>
+            <optional>
+                <ref name="libero.attributes.lang"/>
+            </optional>
             <ref name="libero.text.full.model"/>
         </element>
     </define>
-    
+
     <define name="libero.text.monospace">
         <element name="monospace">
-            <ref name="libero.attrib.lang.optional"/>
+            <optional>
+                <ref name="libero.attributes.lang"/>
+            </optional>
             <ref name="libero.text.limited.model"/>
         </element>
     </define>
-    
+
     <define name="libero.text.sc">
         <element name="sc">
-            <ref name="libero.attrib.lang.optional"/>
+            <optional>
+                <ref name="libero.attributes.lang"/>
+            </optional>
             <ref name="libero.text.limited.model"/>
         </element>
     </define>
 
     <define name="libero.text.sub">
         <element name="sub">
-            <ref name="libero.attrib.lang.optional"/>
+            <optional>
+                <ref name="libero.attributes.lang"/>
+            </optional>
             <ref name="libero.text.limited.model"/>
         </element>
     </define>
 
     <define name="libero.text.sup">
         <element name="sup">
-            <ref name="libero.attrib.lang.optional"/>
+            <optional>
+                <ref name="libero.attributes.lang"/>
+            </optional>
             <ref name="libero.text.limited.model"/>
         </element>
     </define>
@@ -77,7 +91,7 @@
             </choice>
         </oneOrMore>
     </define>
-    
+
     <define name="libero.text.limited.class">
         <choice>
             <ref name="libero.text.b"/>
@@ -87,7 +101,7 @@
             <ref name="libero.text.sup"/>
         </choice>
     </define>
-    
+
     <define name="libero.text.full.model">
         <oneOrMore>
             <choice>
@@ -96,7 +110,7 @@
             </choice>
         </oneOrMore>
     </define>
-    
+
     <define name="libero.text.full.class">
         <choice>
             <ref name="libero.text.a"/>

--- a/api-dummy/public/schemas/libero/extensions/abstract.rng
+++ b/api-dummy/public/schemas/libero/extensions/abstract.rng
@@ -11,7 +11,7 @@
     </define>
 
     <define name="libero.abstract.content">
-        <ref name="libero.attrib.id"/>
+        <ref name="libero.attributes.id"/>
         <ref name="libero.blocks.limited.model"/>
     </define>
 

--- a/api-dummy/public/schemas/libero/extensions/aside.rng
+++ b/api-dummy/public/schemas/libero/extensions/aside.rng
@@ -5,7 +5,7 @@
     <define name="libero.blocks.full.class" combine="choice">
         <ref name="libero.blocks.aside"/>
     </define>
-    
+
     <define name="libero.blocks.aside">
         <element name="aside">
             <ref name="libero.blocks.aside.model"/>
@@ -13,11 +13,15 @@
     </define>
 
     <define name="libero.blocks.aside.model">
-        <ref name="libero.attrib.lang.optional"/>
+        <optional>
+            <ref name="libero.attributes.lang"/>
+        </optional>
         <interleave>
             <ref name="libero.blocks.object.model"/>
             <element name="label">
-                <ref name="libero.attrib.lang.optional"/>
+                <optional>
+                    <ref name="libero.attributes.lang"/>
+                </optional>
                 <ref name="libero.text.limited.model"/>
             </element>
             <element name="content">
@@ -25,5 +29,5 @@
             </element>
         </interleave>
     </define>
-    
+
 </grammar>

--- a/api-dummy/public/schemas/libero/extensions/code.rng
+++ b/api-dummy/public/schemas/libero/extensions/code.rng
@@ -8,7 +8,7 @@
 
     <define name="libero.blocks.code">
         <element name="code">
-            <ref name="libero.attrib.space"/>
+            <ref name="libero.attributes.space"/>
             <text/>
         </element>
     </define>

--- a/api-dummy/public/schemas/libero/extensions/doi.rng
+++ b/api-dummy/public/schemas/libero/extensions/doi.rng
@@ -10,7 +10,7 @@
         <ref name="libero.doi.model"/>
     </define>
 
-    <define name="libero.attrib.id" combine="interleave">
+    <define name="libero.attributes.id" combine="interleave">
         <optional>
             <attribute name="doi">
                 <ref name="libero.types.doi"/>

--- a/api-dummy/public/schemas/libero/extensions/list.rng
+++ b/api-dummy/public/schemas/libero/extensions/list.rng
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <grammar xmlns="http://relaxng.org/ns/structure/1.0" ns="http://libero.pub">
-    
+
     <define name="libero.blocks.limited.class" combine="choice">
         <ref name="libero.blocks.list"/>
     </define>
-    
+
     <define name="libero.blocks.list">
         <element name="list">
             <optional>
@@ -16,13 +16,13 @@
             <ref name="libero.blocks.list.model"/>
         </element>
     </define>
-    
+
     <define name="libero.blocks.list.model">
         <oneOrMore>
             <ref name="libero.blocks.list.item"/>
         </oneOrMore>
     </define>
-    
+
     <define name="libero.blocks.list.prefix">
         <choice>
             <value>alpha-lower</value>
@@ -33,15 +33,17 @@
             <value>roman-upper</value>
         </choice>
     </define>
-    
+
     <define name="libero.blocks.list.item">
         <element name="item">
             <ref name="libero.blocks.list.item.model"/>
         </element>
     </define>
-    
+
     <define name="libero.blocks.list.item.model">
-        <ref name="libero.attrib.lang.optional"/>
+        <optional>
+            <ref name="libero.attributes.lang"/>
+        </optional>
         <choice>
             <ref name="libero.text.full.model"/>
             <ref name="libero.blocks.limited.model"/>

--- a/api-dummy/public/schemas/libero/extensions/mathml.rng
+++ b/api-dummy/public/schemas/libero/extensions/mathml.rng
@@ -27,7 +27,7 @@
 
     <define name="libero.blocks.mathml.content">
         <optional>
-            <ref name="libero.attrib.id"/>
+            <ref name="libero.attributes.id"/>
             <element name="label">
                 <text/>
             </element>

--- a/api-dummy/public/schemas/libero/extensions/quote.rng
+++ b/api-dummy/public/schemas/libero/extensions/quote.rng
@@ -18,7 +18,9 @@
         </element>
         <optional>
             <element name="cite">
-                <ref name="libero.attrib.lang.optional"/>
+                <optional>
+                    <ref name="libero.attributes.lang"/>
+                </optional>
                 <ref name="libero.text.limited.model"/>
             </element>
         </optional>

--- a/api-dummy/public/schemas/libero/extensions/section.rng
+++ b/api-dummy/public/schemas/libero/extensions/section.rng
@@ -14,10 +14,12 @@
     
     <define name="libero.blocks.section.model">
         <optional>
-            <ref name="libero.attrib.id"/>
+            <ref name="libero.attributes.id"/>
         </optional>
         <element name="title">
-            <ref name="libero.attrib.lang.optional"/>
+            <optional>
+                <ref name="libero.attributes.lang"/>
+            </optional>
             <ref name="libero.text.limited.model"/>
         </element>
         <element name="content">

--- a/api-dummy/public/schemas/libero/extensions/table.rng
+++ b/api-dummy/public/schemas/libero/extensions/table.rng
@@ -126,7 +126,9 @@
     </define>
 
     <define name="libero.blocks.table.cell.base">
-        <ref name="libero.attrib.lang.optional"/>
+        <optional>
+            <ref name="libero.attributes.lang"/>
+        </optional>
         <optional>
             <attribute name="align">
                 <choice>

--- a/api-dummy/public/schemas/libero/extensions/youtube.rng
+++ b/api-dummy/public/schemas/libero/extensions/youtube.rng
@@ -1,30 +1,85 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<grammar xmlns="http://relaxng.org/ns/structure/1.0" ns="http://libero.pub" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
-    
+<grammar ns="http://libero.pub" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
+    xmlns="http://relaxng.org/ns/structure/1.0"
+    xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">
+
     <define name="libero.blocks.limited.class" combine="choice">
         <ref name="libero.blocks.youtube"/>
     </define>
-    
-    <define name="libero.blocks.youtube">
-        <element name="youtube">
-            <ref name="libero.blocks.object.model"/>
-            <ref name="libero.blocks.youtube.model"/>
-        </element>
-    </define>
-    
-    <define name="libero.blocks.youtube.model">
-        <attribute name="height">
+
+    <div>
+        <a:documentation>youtube element</a:documentation>
+
+        <define name="libero.blocks.youtube">
+            <element name="youtube">
+                <ref name="libero.blocks.object.model"/>
+                <ref name="libero.blocks.youtube.attributes"/>
+                <ref name="libero.blocks.youtube.content"/>
+            </element>
+        </define>
+
+        <define name="libero.blocks.youtube.attributes">
+            <ref name="libero.blocks.youtube.attributes.height"/>
+            <ref name="libero.blocks.youtube.attributes.width"/>
+        </define>
+
+        <define name="libero.blocks.youtube.content">
+            <ref name="libero.blocks.youtube.content.id"/>
+        </define>
+
+    </div>
+
+    <div>
+        <a:documentation>youtube/@height attribute</a:documentation>
+
+        <define name="libero.blocks.youtube.attributes.height">
+            <attribute name="height">
+                <ref name="libero.blocks.youtube.attributes.height.content"/>
+            </attribute>
+        </define>
+
+        <define name="libero.blocks.youtube.attributes.height.content">
             <data type="positiveInteger"/>
-        </attribute>
-        <attribute name="width">
+        </define>
+
+    </div>
+
+    <div>
+        <a:documentation>youtube/@width attribute</a:documentation>
+
+        <define name="libero.blocks.youtube.attributes.width">
+            <attribute name="width">
+                <ref name="libero.blocks.youtube.attributes.width.content"/>
+            </attribute>
+        </define>
+
+        <define name="libero.blocks.youtube.attributes.width.content">
             <data type="positiveInteger"/>
-        </attribute>
-        <element name="id">
-            <data type="string">
+        </define>
+
+    </div>
+
+    <div>
+        <a:documentation>youtube/id element</a:documentation>
+
+        <define name="libero.blocks.youtube.content.id">
+            <element name="id">
+                <ref name="libero.blocks.youtube.content.id.attributes"/>
+                <ref name="libero.blocks.youtube.content.id.content"/>
+            </element>
+        </define>
+
+        <define name="libero.blocks.youtube.content.id.attributes">
+            <empty/>
+        </define>
+
+        <define name="libero.blocks.youtube.content.id.content">
+            <data type="token">
                 <param name="pattern">[0-9A-Za-z_\-]{10}[048AEIMQUYcgkosw]</param>
             </data>
-        </element>
-    </define>
-    
+        </define>
+
+    </div>
+
 </grammar>


### PR DESCRIPTION
Looking at tidying up the sample schemas a bit, since they should be looked at closely (even though the actual content is important at the this, the mechanism is).

- Provide grouping
    - Also add some documentation
- Clear and consistent naming
- More extensible
    - Each element is in a `<define>` has two sub-`<define>`s, one for attributes, one for elements ('content'), even if they're empty (to allow for easy extension).

---

Used the following for inspiration:

- http://books.xmlschemata.org/relaxng/page2.html
- https://www.oasis-open.org/committees/download.php/51768/proposal-13112-rng-stage-3.html
- https://www.w3.org/MarkUp/2010/xhtml-m12n-relaxng-20101216/
- https://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng