### PR TITLE
Silence missing favicon

### DIFF
--- a/api-dummy/.docker/nginx-server.conf
+++ b/api-dummy/.docker/nginx-server.conf
@@ -3,6 +3,8 @@ server {
     listen 80;
     root /srv/app/public;
 
+    location = /favicon.ico { access_log off; log_not_found off; }
+
     location / {
         try_files $uri /index.php$is_args$args;
     }

--- a/api-gateway/.docker/nginx-server.conf.template
+++ b/api-gateway/.docker/nginx-server.conf.template
@@ -2,6 +2,8 @@ server {
     server_name localhost;
     listen 80;
 
+    location = /favicon.ico { access_log off; log_not_found off; }
+
     location /articles {
         proxy_pass ${ARTICLES};
         proxy_buffering off;

--- a/dashboard/.docker/nginx-server.conf
+++ b/dashboard/.docker/nginx-server.conf
@@ -3,6 +3,8 @@ server {
     listen 80;
     root /srv/app/public;
 
+    location = /favicon.ico { access_log off; log_not_found off; }
+
     location / {
         try_files $uri /index.php$is_args$args;
     }

--- a/journal/.docker/nginx-server.conf
+++ b/journal/.docker/nginx-server.conf
@@ -3,6 +3,8 @@ server {
     listen 80;
     root /srv/app/public;
 
+    location = /favicon.ico { access_log off; log_not_found off; }
+
     location / {
         try_files $uri /index.php$is_args$args;
     }


### PR DESCRIPTION
The 404 ends up in the nginx container logs, possibly hiding more important messages