### PR TITLE
RFC: Event bus ownership

### DIFF
--- a/adr/0004-event-bus-ownership.md
+++ b/adr/0004-event-bus-ownership.md
@@ -18,9 +18,11 @@ Some services may require a generic binding to many other exchanges in the inter
 
 ## Decision
 
-Create an `exchange` for each data type, as part of a service publishing events.
+Create an `exchange` for each data type or activity, as part of a service publishing events.
 
 Create one `queue` as part of a service consuming events.
+
+Bind each `queue` to as many exchanges as needed, using correlation ids to aggregate events relating to the same data type.
 
 A service may have optional binds, which will only subscribe its `queue` to another service's `exchange` if enabled or dynamically configured as a plugin.
 

--- a/adr/0004-event-bus-ownership.md
+++ b/adr/0004-event-bus-ownership.md
@@ -22,7 +22,7 @@ Create an `exchange` for each data type or activity, as part of a service publis
 
 Create one `queue` as part of a service consuming events.
 
-Bind each `queue` to as many exchanges as needed, using correlation ids to aggregate events relating to the same data type.
+Bind each `queue` to as many exchanges as needed.
 
 If an `exchange` from an upstream service is missing, wait and poll until it's present when bootstrapping a service process that wants to bind to it.
 

--- a/adr/0004-event-bus-ownership.md
+++ b/adr/0004-event-bus-ownership.md
@@ -24,9 +24,11 @@ Create one `queue` as part of a service consuming events.
 
 Bind each `queue` to as many exchanges as needed, using correlation ids to aggregate events relating to the same data type.
 
-The consuming-events-from relationship between services is unidirectional and must be acyclic.
+If an `exchange` from an upstream service is missing, wait and poll until it's present when bootstrapping a service process that wants to bind to it.
 
 A service may have optional binds, which will only subscribe its `queue` to another service's `exchange` if enabled or dynamically configured as a plugin.
+
+The consuming-events-from relationship between services is unidirectional and must be acyclic.
 
 ## Consequences
 

--- a/adr/0004-event-bus-ownership.md
+++ b/adr/0004-event-bus-ownership.md
@@ -1,0 +1,38 @@
+# 4. Own event bus exchanges and queues in services
+
+Date: 2018-05-17
+
+## Status
+
+Proposed
+
+## Context
+
+In a service-based architecture, infrastructure needs to be owned by a service so that it is provisioned and maintained as a first class citizen.
+
+The [event system](0001-events-system.md) based on RabbitMQ requires the setup of `exchanges` and `queues` that `bind` to them.
+
+Practical experience developing eLife lead to no mutual dependencies between services, with e.g. service B strictly being downstream from service A with no events feeding back into service A.
+
+Some services may require a generic binding to many other exchanges in the interest of observability, e.g. a dashboard aggregating events from many different services.
+
+## Decision
+
+Create an `exchange` for each data type, as part of a service publishing events.
+
+Create one `queue` as part of a service consuming events.
+
+Create more than one `queue` in a service if specialized behavior is required, in opposition to a generic type of consumer process.
+
+A service may have optional binds, which will only subscribe its `queue` to another service's `exchange` if enabled or dynamically configured as a plugin.
+
+## Consequences
+
+Service have a [partial order](https://en.wikipedia.org/wiki/Partially_ordered_set) to follow for setup.
+
+The consuming-events-from relationship between services is unidirectional and must be acyclic:
+
+- service B, consuming events from A, cannot publish events for A to consume
+- service C, consuming events from B, also cannot publish events for A to consume
+
+The consuming-events-from relationship will often be part of a stronger dependency, like relying on the APIs exposed by service A.

--- a/adr/0004-event-bus-ownership.md
+++ b/adr/0004-event-bus-ownership.md
@@ -22,8 +22,6 @@ Create an `exchange` for each data type, as part of a service publishing events.
 
 Create one `queue` as part of a service consuming events.
 
-Create more than one `queue` in a service if specialized behavior is required, in opposition to a generic type of consumer process.
-
 A service may have optional binds, which will only subscribe its `queue` to another service's `exchange` if enabled or dynamically configured as a plugin.
 
 ## Consequences

--- a/adr/0004-event-bus-ownership.md
+++ b/adr/0004-event-bus-ownership.md
@@ -24,13 +24,15 @@ Create one `queue` as part of a service consuming events.
 
 Bind each `queue` to as many exchanges as needed, using correlation ids to aggregate events relating to the same data type.
 
+The consuming-events-from relationship between services is unidirectional and must be acyclic.
+
 A service may have optional binds, which will only subscribe its `queue` to another service's `exchange` if enabled or dynamically configured as a plugin.
 
 ## Consequences
 
 Service have a [partial order](https://en.wikipedia.org/wiki/Partially_ordered_set) to follow for setup.
 
-The consuming-events-from relationship between services is unidirectional and must be acyclic:
+The acyclic event consumption implies that:
 
 - service B, consuming events from A, cannot publish events for A to consume
 - service C, consuming events from B, also cannot publish events for A to consume

--- a/events/schema.md
+++ b/events/schema.md
@@ -14,7 +14,7 @@ For clarity, the example data is included with JS syntax (e.g. allowing comments
 {
     "eventId": "448278c4-22d6-11e8-b467-0ed5f89f718b",
     "happenedAt": "2018-03-08T12:00:00+00:00",
-    "aggregate": {
+    "entity": {
         "service": "article-store",
         "name": "article-run",
         "identifier": "6551f09a-bd23-4f12-a039-f8fa78ef776a",
@@ -49,7 +49,7 @@ For clarity, the example data is included with JS syntax (e.g. allowing comments
 {
     "eventId": "448278c4-22d6-11e8-b467-0ed5f89f718b",
     "happenedAt": "2018-03-08T12:00:00+00:00",
-    "aggregate": {
+    "entity": {
         "service": "search",
         "name": "indexing",
         "identifier": "18b21fea-5a87-11e8-9c2d-fa7ae01bbebc",
@@ -89,7 +89,7 @@ For clarity, the example data is included with JS syntax (e.g. allowing comments
 {
     "eventId": "448278c4-22d6-11e8-b467-0ed5f89f718b",
     "happenedAt": "2018-03-08T12:00:00+00:00",
-    "aggregate": {
+    "entity": {
         "service": "downstream-sample",
         "name": "deposit",
         "identifier": "2018-03-08/1", # daily attempts
@@ -133,7 +133,7 @@ Unique for all events. It is a UUID version 1 generated with time and a node ide
 
 Identifies when the event has happened (then it can get published, consumed, etc). It follows the `yyyy-mm-ddTHH:MM:SS+00:00` ISO 8601 format, and is expressed in UTC.
 
-### `aggregate`
+### `entity`
 
 Identifies the unit of consistency that has produced the event: article run in the bot, article version in the articles store, podcast episode in journal-cms, an article's set of metrics in metrics, a single profile in profiles.
 
@@ -155,6 +155,6 @@ Is opaque here, and can contain anything as long as it follows naming convention
 
 Can be used to track events across services, grouping them by the kind of session that originated them or the data type they refer to. Could be an article run during ingestion, or a journal page creating a profile.
 
-Represents an array of dictionaries, each following the format of `aggregate`.
+Represents an array of dictionaries, each following the format of `entity`.
 
 Services should normally add correlation ids from events they have triggered them to the new events being produced.

--- a/events/schema.md
+++ b/events/schema.md
@@ -13,33 +13,10 @@ For clarity, the example data is included with JS syntax (e.g. allowing comments
 ```
 {
     "eventId": "448278c4-22d6-11e8-b467-0ed5f89f718b",
+    "runId": "0509e8c3-4dee-4a3a-800a-3fa9fb43f2e8",
     "happenedAt": "2018-03-08T12:00:00+00:00",
-    "entity": {
-        "service": "article-store",
-        "name": "article-run",
-        "identifier": "6551f09a-bd23-4f12-a039-f8fa78ef776a",
-    },
     "type": "deposit-assets-started",
-    "data": {
-        ... 
-    },
-    "correlationIds": [
-        {
-            "service": "article-store",
-            "name": "article",
-            "identifier": "10627",
-        },
-        {
-            "service": "article-store",
-            "name": "article-version",
-            "identifier": "1",
-        },
-        {
-            "service": "article-store",
-            "name": "article-run",
-            "identifier": "6551f09a-bd23-4f12-a039-f8fa78ef776a",
-        },
-    ],
+    "message": "Article 10627 figure archival completed",
 }
 ```
 
@@ -47,39 +24,11 @@ For clarity, the example data is included with JS syntax (e.g. allowing comments
 
 ```
 {
+    "runId": "0509e8c3-4dee-4a3a-800a-3fa9fb43f2e8",
     "eventId": "448278c4-22d6-11e8-b467-0ed5f89f718b",
     "happenedAt": "2018-03-08T12:00:00+00:00",
-    "entity": {
-        "service": "search",
-        "name": "indexing",
-        "identifier": "18b21fea-5a87-11e8-9c2d-fa7ae01bbebc",
-    },
     "type": "search-indexing-started",
-    "data": {
-        ... 
-    },
-    "correlationIds": [
-        {
-            "service": "article-store",
-            "name": "article",
-            "identifier": "10627",
-        },
-        {
-            "service": "article-store",
-            "name": "article-version",
-            "identifier": "1",
-        },
-        {
-            "service": "article-store",
-            "name": "article-run",
-            "identifier": "6551f09a-bd23-4f12-a039-f8fa78ef776a",
-        },
-        {
-            "service": "search",
-            "name": "indexing",
-            "identifier": "18b21fea-5a87-11e8-9c2d-fa7ae01bbebc",
-        },
-    ],
+    "message": "Article keywords parsing started",
 }
 ```
 
@@ -87,43 +36,19 @@ For clarity, the example data is included with JS syntax (e.g. allowing comments
 
 ```
 {
+    "runId": "0509e8c3-4dee-4a3a-800a-3fa9fb43f2e8",
     "eventId": "448278c4-22d6-11e8-b467-0ed5f89f718b",
     "happenedAt": "2018-03-08T12:00:00+00:00",
-    "entity": {
-        "service": "downstream-sample",
-        "name": "deposit",
-        "identifier": "2018-03-08/1", # daily attempts
-    },
     "type": "downstream-crossref-started",
-    "data": {
-        ... 
-    },
-    "correlationIds": [
-        {
-            "service": "article-store",
-            "name": "article",
-            "identifier": "10627",
-        },
-        {
-            "service": "article-store",
-            "name": "article-version",
-            "identifier": "1",
-        },
-        {
-            "service": "article-store",
-            "name": "article-run",
-            "identifier": "6551f09a-bd23-4f12-a039-f8fa78ef776a",
-        },
-        {
-            "service": "downstream-sample",
-            "name": "deposit",
-            "identifier": "2018-03-08/1",
-        },
-    ],
+    "message": "Article being pushed to crossref.org",
 }
 ```
 
 ## Fields
+
+### `runId`
+
+Ties together a single ingestion of an article or other content type across multiple systems. It's an implementation of a correlation id for events across multiple services.
 
 ### `eventId`
 
@@ -132,18 +57,6 @@ Unique for all events. It is a UUID version 1 generated with time and a node ide
 ### `happenedAt` 
 
 Identifies when the event has happened (then it can get published, consumed, etc). It follows the `yyyy-mm-ddTHH:MM:SS+00:00` ISO 8601 format, and is expressed in UTC.
-
-### `entity`
-
-Identifies the unit of consistency that has produced the event: article run in the bot, article version in the articles store, podcast episode in journal-cms, an article's set of metrics in metrics, a single profile in profiles.
-
-All three information are required to uniquely identify it:
-
-- `service`: `[a-z\-]+`
-- `name`: `[a-z\-]+`
-- `identifier`: `.+` (possibly URL-friendly)
-
-This identifier may or may not correspond to a REST resource accessible through the API of the originating service.
 
 ### `type`
 
@@ -155,17 +68,8 @@ A consistent pattern for types describing a transaction is
 - `...-completed` 
 - `...-failed` 
 
-### `data` (optional)
+### `message`
 
-Is opaque here, and can contain anything as long as it follows naming conventions. Events with the same `type` should usually follow the same schema.
+A string containing useful information to log about the event, or diagnostic information to help make sense of errors.
 
-### `correlationIds` (optional)
-
-Can be used to track events across services, linking them to:
-
-- the service and transaction that originated them (`article-run` or `search-indexing` or `deposit`)
-- a real world entity they refer to (`article` or `article-version`)
-
-Modelled as an array of dictionaries, each following the format of `entity`. Order is not important.
-
-Services may add correlation ids from events they have triggered them to the new events being produced.
+For the time being, contains also identifiers that can map a run to a particular content item, such as an article id and version.

--- a/events/schema.md
+++ b/events/schema.md
@@ -143,6 +143,8 @@ All three information are required to uniquely identify it:
 - `name`: `[a-z\-]+`
 - `identifier`: `.+` (possibly URL-friendly)
 
+This identifier may or may not correspond to a REST resource accessible through the API of the originating service.
+
 ### `type`
 
 Describes what the event is about so that they can be grouped or recognized. It follows the `[a-z\-\.]+` regular expression, with `.` separating hierarchical levels and `-` separating words in a single level (if there are multiple words).

--- a/events/schema.md
+++ b/events/schema.md
@@ -155,8 +155,11 @@ Is opaque here, and can contain anything as long as it follows naming convention
 
 ### `correlationIds` (optional)
 
-Can be used to track events across services, grouping them by the kind of session that originated them or the data type they refer to. Could be an article run during ingestion, or a journal page creating a profile.
+Can be used to track events across services, linking them to:
 
-Represents an array of dictionaries, each following the format of `entity`.
+- the service and transaction that originated them (`article-run` or `search-indexing` or `deposit`)
+- a real world entity they refer to (`article` or `article-version`)
 
-Services should normally add correlation ids from events they have triggered them to the new events being produced.
+Modelled as an array of dictionaries, each following the format of `entity`. Order is not important.
+
+Services may add correlation ids from events they have triggered them to the new events being produced.

--- a/events/schema.md
+++ b/events/schema.md
@@ -126,8 +126,8 @@ For clarity, the example data is included with JS syntax (e.g. allowing comments
 ## Fields
 
 - `eventId` is unique for all events. It is a UUID version 1 generated with time and a node identifier.
-- `happenedAt` identifies when the event has happened (then it can get published, consumed, etc).
-- `aggregate` identifies the unit of consistency that has produced the event: article run in the bot, article version in the articles, store podcast episode in journal-cms, an article's set of metrics in metrics, a single profile in profiles. All three information are required to uniquely identify it: `service`, `name`, `identifier`.
-- `type` describes what the event is about so that they can be grouped or recognized.
+- `happenedAt` identifies when the event has happened (then it can get published, consumed, etc). It follows the `yyyy-mm-ddTHH:MM:SS+00:00` ISO 8601 format, and is expressed in UTC.
+- `aggregate` identifies the unit of consistency that has produced the event: article run in the bot, article version in the articles store, podcast episode in journal-cms, an article's set of metrics in metrics, a single profile in profiles. All three information are required to uniquely identify it: `service`, `name`, `identifier`.
+- `type` describes what the event is about so that they can be grouped or recognized. It follows the `[a-z\-\.]+` regular expression, with `.` separating hierarchical levels and `-` separating words in a single level (if there are multiple words).
 - `data` is opaque here, and can contain anything as long as it follows naming conventions. Events with the same `type` should usually follow the same schema.
-- `correlationIds` can be used to track events across services, grouping them by the kind of session that originated them or the data type they refer to. Could be an article run during ingestion, or a journal page creating a profile. It is optional at this time.
+- `correlationIds` can be used to track events across services, grouping them by the kind of session that originated them or the data type they refer to. Could be an article run during ingestion, or a journal page creating a profile. It is optional at this time. Services should normally add correlation ids from events they have triggered them to the new events being produced.

--- a/events/schema.md
+++ b/events/schema.md
@@ -125,9 +125,36 @@ For clarity, the example data is included with JS syntax (e.g. allowing comments
 
 ## Fields
 
-- `eventId` is unique for all events. It is a UUID version 1 generated with time and a node identifier.
-- `happenedAt` identifies when the event has happened (then it can get published, consumed, etc). It follows the `yyyy-mm-ddTHH:MM:SS+00:00` ISO 8601 format, and is expressed in UTC.
-- `aggregate` identifies the unit of consistency that has produced the event: article run in the bot, article version in the articles store, podcast episode in journal-cms, an article's set of metrics in metrics, a single profile in profiles. All three information are required to uniquely identify it: `service`, `name`, `identifier`.
-- `type` describes what the event is about so that they can be grouped or recognized. It follows the `[a-z\-\.]+` regular expression, with `.` separating hierarchical levels and `-` separating words in a single level (if there are multiple words).
-- `data` is opaque here, and can contain anything as long as it follows naming conventions. Events with the same `type` should usually follow the same schema.
-- `correlationIds` can be used to track events across services, grouping them by the kind of session that originated them or the data type they refer to. Could be an article run during ingestion, or a journal page creating a profile. It is optional at this time. Services should normally add correlation ids from events they have triggered them to the new events being produced.
+### `eventId`
+
+Unique for all events. It is a UUID version 1 generated with time and a node identifier.
+
+### `happenedAt` 
+
+Identifies when the event has happened (then it can get published, consumed, etc). It follows the `yyyy-mm-ddTHH:MM:SS+00:00` ISO 8601 format, and is expressed in UTC.
+
+### `aggregate`
+
+Identifies the unit of consistency that has produced the event: article run in the bot, article version in the articles store, podcast episode in journal-cms, an article's set of metrics in metrics, a single profile in profiles.
+
+All three information are required to uniquely identify it:
+
+- `service`: `[a-z\-]+`
+- `name`: `[a-z\-]+`
+- `identifier`: `.+` (possibly URL-friendly)
+
+### `type`
+
+Describes what the event is about so that they can be grouped or recognized. It follows the `[a-z\-\.]+` regular expression, with `.` separating hierarchical levels and `-` separating words in a single level (if there are multiple words).
+
+### `data` (optional)
+
+Is opaque here, and can contain anything as long as it follows naming conventions. Events with the same `type` should usually follow the same schema.
+
+### `correlationIds` (optional)
+
+Can be used to track events across services, grouping them by the kind of session that originated them or the data type they refer to. Could be an article run during ingestion, or a journal page creating a profile.
+
+Represents an array of dictionaries, each following the format of `aggregate`.
+
+Services should normally add correlation ids from events they have triggered them to the new events being produced.

--- a/events/schema.md
+++ b/events/schema.md
@@ -4,12 +4,18 @@ Events published to the bus have a standard schema that allows SDKs and services
 
 The schema is based on JSON (and can be modelled with JSON Schema if necessary).
 
+## Examples
+
+For clarity, the example data is included with JS syntax (e.g. allowing comments) rather than JSON syntax.
+
+### Example: article ingestion from the article store
+
 ```
 {
     "eventId": "448278c4-22d6-11e8-b467-0ed5f89f718b",
     "happenedAt": "2018-03-08T12:00:00+00:00",
     "aggregate": {
-        "service": "bot",
+        "service": "article-store",
         "name": "article-run",
         "identifier": "6551f09a-bd23-4f12-a039-f8fa78ef776a",
     },
@@ -17,17 +23,111 @@ The schema is based on JSON (and can be modelled with JSON Schema if necessary).
     "data": {
         ... 
     },
-    #"correlationId": {
-    #    "service": "journal",
-    #    "name": "page",
-    #    "identifier": "e4c1829b8249fee0e201bec4589b2aa1b394960f",
-    #},
+    "correlationIds": [
+        {
+            "service": "article-store",
+            "name": "article",
+            "identifier": "10627",
+        },
+        {
+            "service": "article-store",
+            "name": "article-version",
+            "identifier": "1",
+        },
+        {
+            "service": "article-store",
+            "name": "article-run",
+            "identifier": "6551f09a-bd23-4f12-a039-f8fa78ef776a",
+        },
+    ],
 }
 ```
+
+### Example: downstream search service indexing an article
+
+```
+{
+    "eventId": "448278c4-22d6-11e8-b467-0ed5f89f718b",
+    "happenedAt": "2018-03-08T12:00:00+00:00",
+    "aggregate": {
+        "service": "search",
+        "name": "indexing",
+        "identifier": "18b21fea-5a87-11e8-9c2d-fa7ae01bbebc",
+    },
+    "type": "search-indexing-started",
+    "data": {
+        ... 
+    },
+    "correlationIds": [
+        {
+            "service": "article-store",
+            "name": "article",
+            "identifier": "10627",
+        },
+        {
+            "service": "article-store",
+            "name": "article-version",
+            "identifier": "1",
+        },
+        {
+            "service": "article-store",
+            "name": "article-run",
+            "identifier": "6551f09a-bd23-4f12-a039-f8fa78ef776a",
+        },
+        {
+            "service": "search",
+            "name": "indexing",
+            "identifier": "18b21fea-5a87-11e8-9c2d-fa7ae01bbebc",
+        },
+    ],
+}
+```
+
+### Example: downstream deposit service pushing an article to Crossref
+
+```
+{
+    "eventId": "448278c4-22d6-11e8-b467-0ed5f89f718b",
+    "happenedAt": "2018-03-08T12:00:00+00:00",
+    "aggregate": {
+        "service": "downstream-sample",
+        "name": "deposit",
+        "identifier": "2018-03-08/1", # daily attempts
+    },
+    "type": "downstream-crossref-started",
+    "data": {
+        ... 
+    },
+    "correlationIds": [
+        {
+            "service": "article-store",
+            "name": "article",
+            "identifier": "10627",
+        },
+        {
+            "service": "article-store",
+            "name": "article-version",
+            "identifier": "1",
+        },
+        {
+            "service": "article-store",
+            "name": "article-run",
+            "identifier": "6551f09a-bd23-4f12-a039-f8fa78ef776a",
+        },
+        {
+            "service": "downstream-sample",
+            "name": "deposit",
+            "identifier": "2018-03-08/1",
+        },
+    ],
+}
+```
+
+## Fields
 
 - `eventId` is unique for all events. It is a UUID version 1 generated with time and a node identifier.
 - `happenedAt` identifies when the event has happened (then it can get published, consumed, etc).
 - `aggregate` identifies the unit of consistency that has produced the event: article run in the bot, article version in the articles, store podcast episode in journal-cms, an article's set of metrics in metrics, a single profile in profiles. All three information are required to uniquely identify it: `service`, `name`, `identifier`.
 - `type` describes what the event is about so that they can be grouped or recognized.
 - `data` is opaque here, and can contain anything as long as it follows naming conventions. Events with the same `type` should usually follow the same schema.
-- `correlationId` can be used to track events across services, grouping them by the kind of session that originated them. Could be an article run during ingestion, or a journal page creating a profile. It is optional at this time.
+- `correlationIds` can be used to track events across services, grouping them by the kind of session that originated them or the data type they refer to. Could be an article run during ingestion, or a journal page creating a profile. It is optional at this time.

--- a/events/schema.md
+++ b/events/schema.md
@@ -149,6 +149,12 @@ This identifier may or may not correspond to a REST resource accessible through 
 
 Describes what the event is about so that they can be grouped or recognized. It follows the `[a-z\-\.]+` regular expression, with `.` separating hierarchical levels and `-` separating words in a single level (if there are multiple words).
 
+A consistent pattern for types describing a transaction is
+
+- `...-started` 
+- `...-completed` 
+- `...-failed` 
+
 ### `data` (optional)
 
 Is opaque here, and can contain anything as long as it follows naming conventions. Events with the same `type` should usually follow the same schema.


### PR DESCRIPTION
For #27, the ADR is limited in space, but the reasoning for it follows.

There is an issue of how project sets up (RabbitMQ terminology used here):

- `exchanges` (formerly known as topics in SQS land)
- `queues`

For `queues`, it's usually each consuming project creating its own queue and binding it to one or more existing exchanges (also there's the flexibility to create multiple queues in a project, subscribing to different things, if that's really needed).

For `exchanges`, they can be created by the owner of the data without creating any binding. This leaves the other projects free to bind something to them or not. We avoided that in eLife 2.0 because there is the potential for mutual dependencies, like:

- `metrics` would own the `metrics` exchange, emitting events for journal-cms to consume
    journal-cms would own the podcast-episodes exchange emitting events for metrics to consume (hypothetical, metrics is not consuming events at the moment)

In general, this mutual dependencies between projects didn't happen:

    journal-cms depends on lax but not the other way around
    search depends on lots of things but doesn't emit events
    metrics depends on lots of things but doesn't emit events
    observer depends on lots of things but doesn't emit events
    annotations depends on profiles but not the other way around
    So we could have each project defines its own exchange if we can guarantee an acyclic graph of dependencies between projects (which is a good thing anyway, docker-compose for example agrees).