### PR TITLE
Don't create the articles exchange in the dashboard

### DIFF
--- a/dashboard/config/packages/old_sound_rabbit_mq.yaml
+++ b/dashboard/config/packages/old_sound_rabbit_mq.yaml
@@ -9,5 +9,6 @@ old_sound_rabbit_mq:
             exchange_options:
                 name: 'articles'
                 type: fanout
+                declare: false
             queue_options:
                 name: 'dashboard'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,7 +145,11 @@ services:
             - APP_SECRET=f6a87c2e031ecadc0d7eb442729435c7
             - DATABASE_URL=pgsql://postgres:@dashboard-postgres:5432/postgres
             - RABBITMQ_URL=amqp://guest:guest@event-bus:5672
-        command: bash -c 'wait-for-port event-bus 5672 && bin/console rabbitmq:consumer events'
+        command: >
+                /bin/bash -c '
+                    until bin/console rabbitmq:setup-fabric; do sleep 1; done
+                    bin/console rabbitmq:consumer events
+                '
         depends_on:
             - event-bus
             - dashboard-postgres


### PR DESCRIPTION
Currently the `articles` exchange isn't created until a message is sent, so the queue will miss the first message.