### PR TITLE
Add wait for services in example.sh

### DIFF
--- a/examples.sh
+++ b/examples.sh
@@ -13,7 +13,7 @@ function line {
 function wait_for_services {
     echo "Waiting for services..."
     while true; do
-        STATUS_CODE=$(curl -o /dev/null --silent --head --write-out '%{http_code}\n' 'http://localhost:8085/articles')
+        STATUS_CODE=$(curl -o /dev/null --silent --head --write-out '%{http_code}' 'http://localhost:8085/articles')
         if [ "$STATUS_CODE" = "200" ]
         then
             break

--- a/examples.sh
+++ b/examples.sh
@@ -11,8 +11,10 @@ function line {
 }
 
 function wait_for_services {
+    TIMEOUT="${2:-30}"
     echo "Waiting for services..."
-    while true; do
+
+    for ((i=1;i<=TIMEOUT;i++)); do
         STATUS_CODE=$(curl -o /dev/null --silent --head --write-out '%{http_code}' 'http://localhost:8085/articles')
         if [ "$STATUS_CODE" = "200" ]
         then

--- a/examples.sh
+++ b/examples.sh
@@ -10,10 +10,23 @@ function line {
     echo -e "\n"
 }
 
+function wait_for_services {
+    echo "Waiting for services..."
+    while true; do
+        STATUS_CODE=$(curl -o /dev/null --silent --head --write-out '%{http_code}\n' 'http://localhost:8085/articles')
+        if [ "$STATUS_CODE" = "200" ]
+        then
+            break
+        fi
+        sleep 1
+    done
+}
+
 function start {
     echo "Starting containers..."
     finish &> /dev/null
     docker-compose up --detach --renew-anon-volumes &> /dev/null
+    wait_for_services
     echo "Done"
 }
 


### PR DESCRIPTION
Resolves an issue getting a 502 if you run through the `example.sh` and hit enter before the `article-store` is ready.

If you have word from the `bash` gods on how to refactor this addition please go ahead, but it does currently solve the issue.